### PR TITLE
v1.4.3 - Update Login Method and fix Login Problem with several Servers like EU

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
 Kodi video plugin that provides video streaming from a https://www.pcloud.com (free or paid) account.
 
+Login Method for several Servers like EU:
+
+  1. After Installation, open pCloud Settings
+  2. At first Tab choose for US Server https://api.plcoud.com and for EU Server https://eapi.plcoud.com
+  3. Than Enter in the correct Tab (api or eapi) your Username and Password and click OK
+  4. Start pCloud and have fun
+
 For Kodi Helix (14.x) and greater).

--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.pcloud-video-streaming" name="PCloud Video Streaming" version="1.4.2" provider-name="Guido Domenici">
+<addon id="plugin.video.pcloud-video-streaming" name="PCloud Video Streaming" version="1.4.3" provider-name="Guido Domenici">
   <requires>
     <import addon="xbmc.python" version="2.19.0"/>
   </requires>

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,11 @@
+v1.4.3 -- 13-Oct-2020
+- Update Login Method and fix Login Problem with several Servers like EU
+  1. After Installation, open pCloud Settings
+  2. At first Tab choose for US Server https://api.plcoud.com and for EU Server https://eapi.plcoud.com
+  3. Than Enter in the correct Tab (api or eapi) your Username and Password and click OK
+  4. Start pCloud and have fun
+  Thx to loki1979
+
 v1.4.2 -- 07-Jun-2020
 - Fixed issue #27: In certain locales (such as en-nz), the "Back to parent folder" list item would sort
   after folders starting with a number. Now it sorts correctly at the top of the list.

--- a/resources/lib/pcloudapi.py
+++ b/resources/lib/pcloudapi.py
@@ -25,7 +25,7 @@ class PCloudApi:
 	def __init__(self):
 		# auth typically comes from xbmcaddon.Addon() followed by myAddon.getSetting("auth")
 		self.auth = None
-		self.PCLOUD_BASE_URL = 'https://api.pcloud.com/'
+		self.PCLOUD_BASE_URL = xbmcaddon.Addon().getSetting("CloudUrl")
 		self.TOKEN_EXPIRATION_SECONDS = 100 * 86400 # 100 days
 		self.HttpHandler = build_opener()
 		self.HttpHandler.addheaders = [('Accept', 'application/json')]

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -2,10 +2,16 @@
 <settings>
     <category label="30100">
 		<!-- Will contain the pcloud auth string, but is only set programmatically -->
-        <setting label="30105" type="text" id="auth" visible="false" default=""/>
-		<setting label="30106" type="text" id="authExpiry" visible="false" default=""/>
-		<!-- Last used folder ID -->
-		<setting label="30112" type="text" id="lastUsedFolderID" visible="false" default="0"/>
+		<setting label="CLOUD URL" type="labelenum" id="CloudUrl" values="https://api.pcloud.com/|https://eapi.pcloud.com/" default="https://api.pcloud.com/"/>
+		<setting type="sep"/>
+		<setting label="API USERNAME" type="text" id="username1" default=""/>
+        <setting label="API PASSWORD" type="text" id="password1" default=""/>
+		<setting type="sep"/>
+		<setting label="EAPI USERNAME" type="text" id="username2" default=""/>
+        <setting label="EAPI PASSWORD" type="text" id="password2" default=""/>
+
+		<setting label="EAPI EXPIRY" type="text" id="authExpiry" visible="false" default=""/>
+		<setting label="LAST USER FOLDER ID" type="text" id="lastUsedFolderID" visible="false" default="0"/>
 	</category>
     <!-- category label="30106">
         <setting label="30107" type="action" action="RunScript(plugin.video.pcloud-video-streaming, downloadreport)"/>


### PR DESCRIPTION
- Update Login Method and fix Login Problem with several Servers like EU
  1. After Installation, open pCloud Settings
  2. At first Tab choose for US Server https://api.plcoud.com and for EU Server https://eapi.plcoud.com
  3. Than Enter in the correct Tab (api or eapi) your Username and Password and click OK
  4. Start pCloud and have fun
  Thx to loki1979